### PR TITLE
Fix unsubscribe/subscribe race condition

### DIFF
--- a/src/pubsub.ts
+++ b/src/pubsub.ts
@@ -116,9 +116,10 @@ export class AMQPPubSub implements PubSubEngine {
   }
 
   private async unsubscribeForKey(routingKey: string): Promise<void> {
-    await this.unsubscribeMap[routingKey]();
-    delete this.subsRefsMap[routingKey];
+    const disposer = this.unsubscribeMap[routingKey];
     delete this.unsubscribeMap[routingKey];
+    delete this.subsRefsMap[routingKey];
+    await disposer();
   }
 
 }


### PR DESCRIPTION
Resolves https://github.com/Surnet/graphql-amqp-subscriptions/issues/10

Ensure disposal of consumer occurs after removal of mapped data. Allows new subscribers to come through on disposal without being deleted form the map.

I will also have a follow up PR that includes some more significant changes that may be beneficial.

TODO:
 - [x] Test case