### PR TITLE
Fix race condition on simultaneous first subscribers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package is influenced by [graphql-redis-subscriptions](https://github.com/d
 [![CircleCI](https://circleci.com/gh/Surnet/graphql-amqp-subscriptions.svg?style=svg)](https://circleci.com/gh/Surnet/graphql-amqp-subscriptions)
 [![Known Vulnerabilities](https://snyk.io/test/github/Surnet/graphql-amqp-subscriptions/badge.svg)](https://snyk.io/test/github/Surnet/graphql-amqp-subscriptions)
 
-# Basic usage
+## Basic usage
 
 ```javascript
 import { AMQPPubSub } from 'graphql-amqp-subscriptions';
@@ -29,14 +29,30 @@ amqp.connect('amqp://guest:guest@localhost:5672?heartbeat=30')
 });
 ```
 
-# Benefits
+## Benefits
 
 - Reusing existing [amqplib](https://github.com/squaremo/amqp.node) Connection
 - Reusing channels (one for subscriptions, one for publishing)
 - Performance/Ressource-usage benefits on AMQP (RabbitMQ) because of the aforementioned reasons [more info](https://www.cloudamqp.com/blog/2018-01-19-part4-rabbitmq-13-common-errors.html)
 - Using Topic Exchange (e.g. you publish to `agreements.eu.berlin.headstore` and subscribe to `agreements.eu.#`) [more info](https://www.cloudamqp.com/blog/2015-09-03-part4-rabbitmq-for-beginners-exchanges-routing-keys-bindings.html)
 
-# Debug
+## Debug
 
 This package uses Debug.
 To show the logs run your app with the environment variable DEBUG="AMQPPubSub"
+
+## Tests
+
+You'll need to have a local AMPQ instance such as RabbitMQ running to run tests.
+
+If you have [Docker](https://www.docker.com/), you can run:
+
+```bash
+docker run --hostname my-rabbit -p 5672:5672 rabbitmq:3
+```
+
+Then
+
+```bash
+npm test
+```

--- a/src/amqp/publisher.test.ts
+++ b/src/amqp/publisher.test.ts
@@ -12,25 +12,12 @@ let publisher: AMQPPublisher;
 
 describe('AMQP Publisher', () => {
 
-  before((done) => {
-    amqp.connect('amqp://guest:guest@localhost:5672?heartbeat=30')
-    .then(amqpConn => {
-      conn = amqpConn;
-      done();
-    })
-    .catch(err => {
-      done(err);
-    });
+  before(async () => {
+    conn = await amqp.connect('amqp://guest:guest@localhost:5672?heartbeat=30');
   });
 
-  after((done) => {
-    conn.close()
-    .then(() => {
-      done();
-    })
-    .catch(err => {
-      done(err);
-    });
+  after(async () => {
+    return conn.close();
   });
 
   it('should create new instance of AMQPPublisher class', () => {
@@ -38,26 +25,12 @@ describe('AMQP Publisher', () => {
     expect(publisher).to.exist;
   });
 
-  it('should publish a message to an exchange', (done) => {
-    publisher.publish('exchange', 'test.test', {test: 'data'})
-    .then(() => {
-      done();
-    })
-    .catch(err => {
-      expect(err).to.not.exist;
-      done();
-    });
+  it('should publish multiple messages to an exchange', async () => {
+    return publisher.publish('exchange', 'test.test', {test: 'data'});
   });
 
-  it('should publish a second message to an exchange', (done) => {
-    publisher.publish('exchange', 'test.test', {test: 'data'})
-    .then(() => {
-      done();
-    })
-    .catch(err => {
-      expect(err).to.not.exist;
-      done();
-    });
+  it('should publish a second message to an exchange', async () => {
+    return publisher.publish('exchange', 'test.test', {test: 'data'});
   });
 
 });

--- a/src/amqp/publisher.ts
+++ b/src/amqp/publisher.ts
@@ -13,24 +13,17 @@ export class AMQPPublisher {
   }
 
   public async publish(exchange: string, routingKey: string, data: any): Promise<void> {
-    let promise: PromiseLike<amqp.Channel>;
-    if (this.channel) {
-      promise = Promise.resolve(this.channel);
-    } else {
-      promise = this.connection.createChannel();
+    const channel = await this.getOrCreateChannel();
+    await channel.assertExchange(exchange, 'topic', { durable: false, autoDelete: false });
+    await channel.publish(exchange, routingKey, Buffer.from(JSON.stringify(data)));
+    this.logger('Message sent to Exchange "%s" with Routing Key "%s" (%j)', exchange, routingKey, data);
+  }
+
+  private async getOrCreateChannel(): Promise<amqp.Channel> {
+    if (!this.channel) {
+      this.channel = await this.connection.createChannel();
+      this.channel.on('error', (err) => { this.logger('Publisher channel error: "%j"', err); });
     }
-    return promise
-    .then(async ch => {
-      this.channel = ch;
-      return ch.assertExchange(exchange, 'topic', { durable: false, autoDelete: false })
-      .then(() => {
-        this.logger('Message sent to Exchange "%s" with Routing Key "%s" (%j)', exchange, routingKey, data);
-        ch.publish(exchange, routingKey, Buffer.from(JSON.stringify(data)));
-        return Promise.resolve();
-      })
-      .catch(err => {
-        return Promise.reject(err);
-      });
-    });
+    return this.channel;
   }
 }

--- a/src/amqp/subscriber.test.ts
+++ b/src/amqp/subscriber.test.ts
@@ -5,6 +5,14 @@ import { expect } from 'chai';
 import 'mocha';
 import Debug from 'debug';
 import amqp from 'amqplib';
+import { EventEmitter } from 'events';
+
+type TestData = {
+  routingKey: string,
+  message: {
+    test: string
+  }
+};
 
 const logger = Debug('AMQPPubSub');
 
@@ -14,25 +22,12 @@ let publisher: AMQPPublisher;
 
 describe('AMQP Subscriber', () => {
 
-  before((done) => {
-    amqp.connect('amqp://guest:guest@localhost:5672?heartbeat=30')
-    .then(amqpConn => {
-      conn = amqpConn;
-      done();
-    })
-    .catch(err => {
-      done(err);
-    });
+  before(async () => {
+    conn = await amqp.connect('amqp://guest:guest@localhost:5672?heartbeat=30');
   });
 
-  after((done) => {
-    conn.close()
-    .then(() => {
-      done();
-    })
-    .catch(err => {
-      done(err);
-    });
+  after(async () => {
+    return conn.close();
   });
 
   it('should create new instance of AMQPSubscriber class', () => {
@@ -45,46 +40,38 @@ describe('AMQP Subscriber', () => {
     expect(publisher).to.exist;
   });
 
-  it('should be able to receive a message through an exchange', (done) => {
-    subscriber.subscribe('exchange', '*.test', (routingKey, message) => {
-      expect(routingKey).to.exist;
-      expect(message).to.exist;
-      expect(message.test).to.exist;
-      expect(message.test).to.equal('data');
-      done();
-    })
-    .then(disposer => {
-      expect(disposer).to.exist;
-      publisher.publish('exchange', 'test.test', {test: 'data'})
-      .then(() => {
-        expect(true).to.equal(true);
-      })
-      .catch(err => {
-        expect(err).to.not.exist;
-        done();
-      });
-    })
-    .catch(err => {
-      expect(err).to.not.exist;
-      done();
+  it('should be able to receive a message through an exchange', async () => {
+    const emitter = new EventEmitter();
+    const msgPromise = new Promise<TestData>((resolve) => { emitter.once('message', resolve); });
+
+    const dispose = await subscriber.subscribe('exchange', '*.test', (routingKey, message) => {
+      emitter.emit('message', { routingKey, message });
     });
+    expect(dispose).to.exist;
+
+    await publisher.publish('exchange', 'test.test', {test: 'data'});
+    const { routingKey: key, message: msg } = await msgPromise;
+
+    expect(key).to.exist;
+    expect(msg).to.exist;
+    expect(msg.test).to.exist;
+    expect(msg.test).to.equal('data');
+
+    return dispose();
   });
 
-  it('should be able to unsubscribe', (done) => {
-    subscriber.subscribe('exchange', 'test.test', () => {
-      done(new Error('Should not reach'));
-    })
-    .then(disposer => {
-      expect(disposer).to.exist;
-      disposer()
-      .then(() => {
-        done();
-      });
-    })
-    .catch(err => {
-      expect(err).to.not.exist;
-      done();
+  it('should be able to unsubscribe', async () => {
+    const emitter = new EventEmitter();
+    const errPromise = new Promise((_resolve, reject) => { emitter.once('error', reject); });
+
+    const dispose = await subscriber.subscribe('exchange', 'test.test', () => {
+      emitter.emit('error', new Error('Should not reach'));
     });
+
+    return Promise.race([
+      dispose,
+      errPromise
+    ]);
   });
 
 });

--- a/src/amqp/subscriber.ts
+++ b/src/amqp/subscriber.ts
@@ -18,44 +18,34 @@ export class AMQPSubscriber {
     exchange: string,
     routingKey: string,
     action: (routingKey: string, message: any) => void
-  ): Promise<() => PromiseLike<any>> {
-    let promise: PromiseLike<amqp.Channel>;
-    if (this.channel) {
-      promise = Promise.resolve(this.channel);
-    } else {
-      promise = this.connection.createChannel();
-    }
-    return promise
-    .then(async ch => {
-      this.channel = ch;
-      return ch.assertExchange(exchange, 'topic', { durable: false, autoDelete: false })
-      .then(() => {
-        return ch.assertQueue('', { exclusive: true, durable: false, autoDelete: true });
-      })
-      .then(async queue => {
-        return ch.bindQueue(queue.queue, exchange, routingKey)
-        .then(() => {
-          return queue;
-        });
-      })
-      .then(async queue => {
-        return ch.consume(queue.queue, (msg) => {
-          let parsedMessage = Logger.convertMessage(msg);
-          this.logger('Message arrived from Queue "%s" (%j)', queue.queue, parsedMessage);
-          action(routingKey, parsedMessage);
-        }, {noAck: true})
-        .then(opts => {
-          this.logger('Subscribed to Queue "%s" (%s)', queue.queue, opts.consumerTag);
-          return ((): PromiseLike<any> => {
-            this.logger('Disposing Subscriber to Queue "%s" (%s)', queue.queue, opts.consumerTag);
-            return ch.cancel(opts.consumerTag);
-          });
-        });
-      })
-      .catch(err => {
-        return Promise.reject(err);
-      });
-    });
+  ): Promise<() => Promise<void>> {
+    // Create and bind queue
+    const channel = await this.getOrCreateChannel();
+    await channel.assertExchange(exchange, 'topic', { durable: false, autoDelete: false });
+    const queue = await channel.assertQueue('', { exclusive: true, durable: false, autoDelete: true });
+    await channel.bindQueue(queue.queue, exchange, routingKey);
+
+    // Listen for messages
+    const opts = await channel.consume(queue.queue, (msg) => {
+      let parsedMessage = Logger.convertMessage(msg);
+      this.logger('Message arrived from Queue "%s" (%j)', queue.queue, parsedMessage);
+      action(routingKey, parsedMessage);
+    }, {noAck: true});
+    this.logger('Subscribed to Queue "%s" (%s)', queue.queue, opts.consumerTag);
+
+    // Dispose callback
+    return async (): Promise<void> => {
+      this.logger('Disposing Subscriber to Queue "%s" (%s)', queue.queue, opts.consumerTag);
+      const ch = await this.getOrCreateChannel();
+      await ch.cancel(opts.consumerTag);
+    };
   }
 
+  private async getOrCreateChannel(): Promise<amqp.Channel> {
+    if (!this.channel) {
+      this.channel = await this.connection.createChannel();
+      this.channel.on('error', (err) => { this.logger('Subscriber channel error: "%j"', err); });
+    }
+    return this.channel;
+  }
 }

--- a/src/pubsub-async-iterator.ts
+++ b/src/pubsub-async-iterator.ts
@@ -101,7 +101,7 @@ export class PubSubAsyncIterator<T> implements AsyncIterator<T> {
 
   private subscribeAll() {
     return Promise.all(this.eventsArray.map(
-      eventName => this.pubsub.subscribe(eventName, this.pushValue.bind(this), {}),
+      eventName => this.pubsub.subscribe(eventName, this.pushValue.bind(this), {})
     ));
   }
 

--- a/src/pubsub.test.ts
+++ b/src/pubsub.test.ts
@@ -5,188 +5,156 @@ import 'mocha';
 import amqp from 'amqplib';
 import { EventEmitter } from 'events';
 
+type TestData = { test: string };
+
 let conn: amqp.Connection;
 let pubsub: AMQPPubSub;
 
 describe('AMQP PubSub', () => {
 
-  before((done) => {
-    amqp.connect('amqp://guest:guest@localhost:5672?heartbeat=30')
-    .then(amqpConn => {
-      conn = amqpConn;
-      done();
-    })
-    .catch(err => {
-      done(err);
-    });
+  before(async () => {
+    conn = await amqp.connect('amqp://guest:guest@localhost:5672?heartbeat=30');
   });
 
   beforeEach(() => {
     pubsub = new AMQPPubSub({ connection: conn });
   });
 
-  after((done) => {
-    conn.close()
-    .then(() => {
-      done();
-    })
-    .catch(err => {
-      done(err);
-    });
+  after(async () => {
+    return conn.close();
   });
 
   it('should create new instance of AMQPPubSub class', () => {
     expect(pubsub).to.exist;
   });
 
-  it('should be able to receive a message with the appropriate routingKey', (done) => {
-    pubsub.subscribe('testx.*', (message) => {
-      expect(message).to.exist;
-      expect(message.test).to.equal('data');
-      done();
-    })
-    .then(subscriberId => {
-      expect(subscriberId).to.exist;
-      pubsub.publish('testx.test', {test: 'data'})
-      .then(() => {
-        expect(true).to.equal(true);
-      })
-      .catch(err => {
-        expect(err).to.not.exist;
-        done();
-      });
-    })
-    .catch(err => {
-      expect(err).to.not.exist;
-      done();
+  it('should be able to receive a message with the appropriate routingKey', async () => {
+    const emitter = new EventEmitter();
+    const msgPromise = new Promise<TestData>((resolve) => { emitter.once('message', resolve); });
+
+    const subscriberId = await pubsub.subscribe('testx.*', (message) => {
+      emitter.emit('message', message);
     });
+    expect(subscriberId).to.exist;
+    expect(isNaN(subscriberId)).to.equal(false);
+
+    await pubsub.publish('testx.test', {test: 'data'});
+    const msg = await msgPromise;
+
+    expect(msg).to.exist;
+    expect(msg.test).to.equal('data');
   });
 
-  it('should be able to unsubscribe', (done) => {
-    pubsub.subscribe('test.test', () => {
-      done(new Error('Should not reach'));
-    })
-    .then(subscriberId => {
-      expect(subscriberId).to.exist;
-      expect(isNaN(subscriberId)).to.equal(false);
-      pubsub.unsubscribe(subscriberId)
-      .then(() => {
-        done();
-      })
-      .catch(err => {
-        expect(err).to.not.exist;
-      });
-    })
-    .catch(err => {
-      expect(err).to.not.exist;
-      done();
+  it('should be able to unsubscribe', async () => {
+    const emitter = new EventEmitter();
+    const errPromise = new Promise<TestData>((_resolve, reject) => { emitter.once('error', reject); });
+
+    const subscriberId = await pubsub.subscribe('test.test', () => {
+      emitter.emit('error', new Error('Should not reach'));
     });
+
+    expect(subscriberId).to.exist;
+    expect(isNaN(subscriberId)).to.equal(false);
+
+    return Promise.race([
+      pubsub.unsubscribe(subscriberId),
+      errPromise
+    ]);
   });
 
-  it('should be able to receive a message after one of two subscribers unsubscribed', (done) => {
+  it('should be able to receive a message after one of two subscribers unsubscribed', async () => {
+    const emitter = new EventEmitter();
+    const errPromise = new Promise<TestData>((_resolve, reject) => { emitter.once('error', reject); });
+    const msgPromise = new Promise<TestData>((resolve) => { emitter.once('message', resolve); });
+
     // Subscribe two
-    pubsub.subscribe('testy.test', () => {
-      done(new Error('Should not reach'));
-    })
-    .then(id1 => {
-      pubsub.subscribe('testy.test', (message) => {
-        // Receive message
-        expect(message).to.exist;
-        expect(message.test).to.equal('data');
-        done();
-      })
-      .then(id2 => {
-        expect(id1).to.exist;
-        expect(id2).to.exist;
-        expect(id1).to.not.equal(id2);
-        // Unsubscribe one
-        pubsub.unsubscribe(id1)
-        .then(() => {
-          pubsub.publish('testy.test', {test: 'data'})
-          .then(() => {
-            expect(true).to.equal(true);
-          })
-          .catch(err => {
-            expect(err).to.not.exist;
-            done();
-          });
-        })
-        .catch(err => {
-          expect(err).to.not.exist;
-        });
-      })
-      .catch(err => {
-        expect(err).to.not.exist;
-      });
-    })
-    .catch(err => {
-      expect(err).to.not.exist;
-      done();
-    });
-  });
-
-  it('should be able to receive a message after one of two subscribers unsubscribed (concurrent)', (done) => {
-    // Subscribe two
-    Promise.all([
-      pubsub.subscribe('testz.test', () => {
-        done(new Error('Should not reach'));
-      }),
-      pubsub.subscribe('testz.test', (message) => {
-        // Receive message
-        expect(message).to.exist;
-        expect(message.test).to.equal('data');
-        done();
-      })
-    ])
-    .then(([id1, id2]) => {
-      expect(id1).to.exist;
-      expect(id2).to.exist;
-      expect(id1).to.not.equal(id2);
-      // Unsubscribe one
-      pubsub.unsubscribe(id1)
-      .then(() => {
-        pubsub.publish('testz.test', {test: 'data'})
-        .then(() => {
-          expect(true).to.equal(true);
-        })
-        .catch(err => {
-          expect(err).to.not.exist;
-          done();
-        });
-      })
-      .catch(err => {
-        expect(err).to.not.exist;
-      });
-    })
-    .catch(err => {
-      expect(err).to.not.exist;
-      done();
-    });
-  });
-
-  it('should be able to receive a message after an unsubscribe and then an immediate subscribe', async () => {
-    // Subscribe one
     const id1 = await pubsub.subscribe('testy.test', () => {
-      throw new Error('Should not reach');
+      emitter.emit('error', new Error('Should not reach'));
     });
     expect(id1).to.exist;
 
+    const id2 = await pubsub.subscribe('testy.test', (message) => {
+      emitter.emit('message', message);
+    });
+
+    expect(id2).to.exist;
+    expect(id1).to.not.equal(id2);
+
+    // Unsubscribe one
+    await pubsub.unsubscribe(id1);
+
+    await pubsub.publish('testy.test', {test: '1335'});
+    const msg = await Promise.race<TestData>([
+      msgPromise,
+      errPromise
+    ]);
+
+    // Receive message
+    expect(msg).to.exist;
+    expect(msg.test).to.equal('1335');
+  });
+
+  it('should be able to receive a message after one of two subscribers unsubscribed (concurrent)', async () => {
     const emitter = new EventEmitter();
-    const msgPromise = new Promise<{ test: string }>((resolve) => emitter.once('message', resolve));
+    const errPromise = new Promise<TestData>((_resolve, reject) => { emitter.once('error', reject); });
+    const msgPromise = new Promise<TestData>((resolve) => { emitter.once('message', resolve); });
+
+    // Subscribe two
+    const [id1, id2] = await Promise.all([
+      pubsub.subscribe('testz.test', () => {
+        emitter.emit('error', new Error('Should not reach'));
+      }),
+      pubsub.subscribe('testz.test', (message) => {
+        emitter.emit('message', message);
+      })
+    ]);
+
+    expect(id1).to.exist;
+    expect(id2).to.exist;
+    expect(id1).to.not.equal(id2);
+
+    // Unsubscribe one
+    await pubsub.unsubscribe(id1);
+
+    await pubsub.publish('testz.test', {test: '1336'});
+    const msg = await Promise.race<TestData>([
+      msgPromise,
+      errPromise
+    ]);
+
+    // Receive message
+    expect(msg).to.exist;
+    expect(msg.test).to.equal('1336');
+  });
+
+  it('should be able to receive a message after an unsubscribe and then an immediate subscribe', async () => {
+    const emitter = new EventEmitter();
+    const errPromise = new Promise<TestData>((_resolve, reject) => { emitter.once('error', reject); });
+
+    // Subscribe one
+    const id1 = await pubsub.subscribe('testy.test', () => {
+      emitter.emit('error', new Error('Should not reach'));
+    });
+    expect(id1).to.exist;
+
+    const msgPromise = new Promise<TestData>((resolve) => { emitter.once('message', resolve); });
 
     // Unsub one, sub while unsub is running
     const [, id2] = await Promise.all([
       pubsub.unsubscribe(id1),
       pubsub.subscribe('testy.test', (message) => {
         emitter.emit('message', message);
-      }),
+      })
     ]);
 
     expect(id2).to.exist;
     expect(id1).to.not.equal(id2);
 
     await pubsub.publish('testy.test', {test: '1337'});
-    const msg = await msgPromise;
+    const msg = await Promise.race<TestData>([
+      msgPromise,
+      errPromise
+    ]);
 
     // Receive message
     expect(msg).to.exist;

--- a/tslint.json
+++ b/tslint.json
@@ -91,7 +91,7 @@
     "switch-default": true,
     "trailing-comma": [
       true,
-      "never"
+      {"multiline": "never", "singleline": "never"}
     ],
     "triple-equals": [
       true,


### PR DESCRIPTION
Fix a race condition where multiple first subscribers to a routing key would cause the last subscription to overwrite data from the first.
Moved core code to async/await over then/catch.
Moved most tests to async/await as well.

Resolves https://github.com/Surnet/graphql-amqp-subscriptions/issues/10

I ran the tests 10 times in a row to confirm there were no more intermittent issues using the following script:
`multi-run.sh`
```bash
#!/usr/bin/env bash

for i in {1..10}
do
  echo "------------------------------"
  echo "| Test run # ${i}"
  echo "------------------------------"

  npm test

  if [ $? -ne 0 ]
  then
    exit $?
  fi
done

 echo "------------------------------"
 echo "| Done"
 echo "------------------------------"
```