### PR TITLE
Fix Imports in Interfaces

### DIFF
--- a/src/amqp/interfaces.ts
+++ b/src/amqp/interfaces.ts
@@ -1,20 +1,20 @@
-import amqp from 'amqplib';
+import {Options, Connection} from 'amqplib';
 
 export interface Exchange {
   name: string;
   type: string;
-  options?: amqp.Options.AssertExchange;
+  options?: Options.AssertExchange;
 }
 
 export interface Queue {
   name?: string;
-  options?: amqp.Options.AssertQueue;
+  options?: Options.AssertQueue;
   unbindOnDispose?: boolean;
   deleteOnDispose?: boolean;
 }
 
 export interface PubSubAMQPConfig {
-  connection: amqp.Connection;
+  connection: Connection;
   exchange?: Exchange;
   queue?: Queue;
 }


### PR DESCRIPTION
Since [types/apmqlib](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/amqplib/index.d.ts#L12) Doesn't export apmq default, I updated the imports here to explicitly pull in what was necessary: (Options and Connections). 